### PR TITLE
Specified minimum gradle version required

### DIFF
--- a/docs/vnfm-how-to-write.md
+++ b/docs/vnfm-how-to-write.md
@@ -654,14 +654,13 @@ public class MyVNFM extends AbstractVnfmSpringJMS {
             Registry registry = LocateRegistry.createRegistry(registryport);
 			int managementPort = 55672; // rabbitmq managment port
             PluginStartup.startPluginRecursive("./plugins",  		// plugins folder
-											   true, 				// wait for plugin to start 
-											   "localhost", 		// rabbitmq broker ip
-											   "" + registryport,	
-											   2,					// no. of consumers
-                                               "admin",				// rabbitmq broker username
-                                               "openbaton",			// rabbitmq broker passwd
-                                               "" + managementPort  // rabbitmq broker mng. port 
-											   );
+                                               true, 				// wait for plugin to start 
+                                               "localhost", 		// rabbitmq broker ip 
+                                               "" + registryport, 
+                                               2,					// no. of consumers 
+                                               "admin",				// rabbitmq broker username 
+                                               "openbaton",			// rabbitmq broker passwd 
+                                               "" + managementPort  // rabbitmq broker mng. port );
         } catch (IOException e) {
             log.error(e.getMessage(), e);
         }

--- a/docs/vnfm-how-to-write.md
+++ b/docs/vnfm-how-to-write.md
@@ -165,9 +165,7 @@ This gradle configuration file needs to contain initially the following lines.
 ```gradle
 buildscript {
     repositories {
-        jcenter()
-        maven { url " http://repo.spring.io/snapshot " }
-        maven { url " http://repo.spring.io/milestone " }
+        mavenCentral()
     }
 
     dependencies {
@@ -177,17 +175,6 @@ buildscript {
 
 apply plugin: 'java'
 apply plugin: 'spring-boot'
-apply plugin: 'maven'
-
-jar {
-    baseName = 'simple-vnfm'
-    version =  '0.0.1-SNAPSHOT'
-}
-
-dependencies {
-    compile("org.springframework.boot:spring-boot-starter-web")
-    testCompile("org.springframework.boot:spring-boot-starter-test")
-}
 ```
 
 The second gradle configuration is called settings.gradle.

--- a/docs/vnfm-how-to-write.md
+++ b/docs/vnfm-how-to-write.md
@@ -169,7 +169,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.2.6.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.3.1.RELEASE")
     }
 }
 

--- a/docs/vnfm-how-to-write.md
+++ b/docs/vnfm-how-to-write.md
@@ -137,7 +137,7 @@ This creates the java folder src/main/java with the proposed package name org.op
 In the next step you create the Main Class called MyVNFM in this case.
 
 ```bash
-$ vim /src/main/java/org/openbaton/vnfm/MyVNFM.java
+$ vim src/main/java/org/openbaton/vnfm/MyVNFM.java
 ```
 At this point you create only the basic Java Class used later as the Main Class for implementing your VNFManager.
 The newly created Java Class should contain the following lines for now.

--- a/docs/vnfm-how-to-write.md
+++ b/docs/vnfm-how-to-write.md
@@ -419,7 +419,9 @@ public class MyVNFM extends AbstractVnfmSpringJMS {
      * @param scripts
      */
     @Override
-    public VirtualNetworkFunctionRecord instantiate(VirtualNetworkFunctionRecord virtualNetworkFunctionRecord, Object scripts) throws Exception {
+    public VirtualNetworkFunctionRecord instantiate(VirtualNetworkFunctionRecord virtualNetworkFunctionRecord, 
+	                                                Object scripts) throws Exception 
+	{
         return virtualNetworkFunctionRecord;
     }
 
@@ -437,8 +439,13 @@ public class MyVNFM extends AbstractVnfmSpringJMS {
      * (out/in, up/down) a VNF instance.
      */
     @Override
-    public void scale() {
-
+    public VirtualNetworkFunctionRecord scale(Action scaleInOrOut, 
+                                              VirtualNetworkFunctionRecord virtualNetworkFunctionRecord, 
+                                              VNFCInstance component, 
+                                              Object scripts, 
+                                              VNFRecordDependency dependency) throws Exception 
+	{
+		return virtualNetworkFunctionRecord;
     }
 
     /**
@@ -455,8 +462,11 @@ public class MyVNFM extends AbstractVnfmSpringJMS {
      * the VNF instantiation is possible.
      */
     @Override
-    public void heal() {
-
+    public VirtualNetworkFunctionRecord heal(VirtualNetworkFunctionRecord virtualNetworkFunctionRecord,
+                                             VNFCInstance component,
+                                             String cause) throws Exception
+    {
+        return virtualNetworkFunctionRecord;
     }
 
     /**
@@ -476,7 +486,9 @@ public class MyVNFM extends AbstractVnfmSpringJMS {
      * @param dependency
      */
     @Override
-    public VirtualNetworkFunctionRecord modify(VirtualNetworkFunctionRecord virtualNetworkFunctionRecord, VNFRecordDependency dependency) throws Exception {
+    public VirtualNetworkFunctionRecord modify(VirtualNetworkFunctionRecord virtualNetworkFunctionRecord, 
+											   VNFRecordDependency dependency) throws Exception 
+	{
         return virtualNetworkFunctionRecord;
     }
 
@@ -495,7 +507,8 @@ public class MyVNFM extends AbstractVnfmSpringJMS {
      * @param virtualNetworkFunctionRecord
      */
     @Override
-    public VirtualNetworkFunctionRecord terminate(VirtualNetworkFunctionRecord virtualNetworkFunctionRecord) throws Exception{
+    public VirtualNetworkFunctionRecord terminate(VirtualNetworkFunctionRecord virtualNetworkFunctionRecord) throws Exception 
+	{
         return virtualNetworkFunctionRecord;
     }
 
@@ -505,7 +518,8 @@ public class MyVNFM extends AbstractVnfmSpringJMS {
     }
 
     @Override
-    public VirtualNetworkFunctionRecord start(VirtualNetworkFunctionRecord virtualNetworkFunctionRecord) throws Exception {
+    public VirtualNetworkFunctionRecord start(VirtualNetworkFunctionRecord virtualNetworkFunctionRecord) throws Exception 
+	{
         return virtualNetworkFunctionRecord;
     }
 
@@ -522,6 +536,12 @@ public class MyVNFM extends AbstractVnfmSpringJMS {
 	public void NotifyChange() {
 
     }
+
+    @Override
+    public void handleError(VirtualNetworkFunctionRecord virtualNetworkFunctionRecord) {
+
+    }
+
 
 	public static void main(String[] args){
         SpringApplication.run(MyVNFM.class);
@@ -629,14 +649,23 @@ public class MyVNFM extends AbstractVnfmSpringJMS {
     @Override
     protected void setup() {
         super.setup();
+		int registryport = 19345;
         try {
-            int registryport = 19345;
             Registry registry = LocateRegistry.createRegistry(registryport);
-            PluginStartup.startPluginRecursive("./plugins", true, "localhost", "" + registryport);
+			int managementPort = 55672; // rabbitmq managment port
+            PluginStartup.startPluginRecursive("./plugins",  		// plugins folder
+											   true, 				// wait for plugin to start 
+											   "localhost", 		// rabbitmq broker ip
+											   "" + registryport,	
+											   2,					// no. of consumers
+                                               "admin",				// rabbitmq broker username
+                                               "openbaton",			// rabbitmq broker passwd
+                                               "" + managementPort  // rabbitmq broker mng. port 
+											   );
         } catch (IOException e) {
             log.error(e.getMessage(), e);
         }
-        resourceManagement = (ResourceManagement) context.getBean("openstackVIM", "openstack", 19345);
+        resourceManagement = (ResourceManagement) context.getBean("openstackVIM", "openstack", registryport);
     }
 }
 ```

--- a/docs/vnfm-how-to-write.md
+++ b/docs/vnfm-how-to-write.md
@@ -14,7 +14,7 @@ The vnfm-sdk provides the following things:
 Before you can start with developing your own VNFManager you need to prepare your programming environment by installing/configuring the following requirements:
 
 * JDK 7 ([installation][openjdk-link])
-* Gradle ([installation][gradle-installation-link])
+* Gradle 1.12 or above ([installation][gradle-installation-link])
 
 ## Develop your own VNFManager
 

--- a/docs/vnfm-how-to-write.md
+++ b/docs/vnfm-how-to-write.md
@@ -164,16 +164,30 @@ This gradle configuration file needs to contain initially the following lines.
 
 ```gradle
 buildscript {
+    repositories {
+        jcenter()
+        maven { url " http://repo.spring.io/snapshot " }
+        maven { url " http://repo.spring.io/milestone " }
+    }
+
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:1.2.6.RELEASE")
     }
 }
-group 'your.group'
-version '1.0-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'spring-boot'
 apply plugin: 'maven'
+
+jar {
+    baseName = 'simple-vnfm'
+    version =  '0.0.1-SNAPSHOT'
+}
+
+dependencies {
+    compile("org.springframework.boot:spring-boot-starter-web")
+    testCompile("org.springframework.boot:spring-boot-starter-test")
+}
 ```
 
 The second gradle configuration is called settings.gradle.

--- a/docs/vnfm-how-to-write.md
+++ b/docs/vnfm-how-to-write.md
@@ -358,7 +358,7 @@ group 'your.group'
 version '1.0-SNAPSHOT'
  
 bootRepackage {
-    mainClass = 'org.openbaton.vnfm.SimpleVNFM'
+    mainClass = 'org.openbaton.vnfm.MyVNFM'
 }
 ```
 

--- a/docs/vnfm-how-to-write.md
+++ b/docs/vnfm-how-to-write.md
@@ -330,29 +330,36 @@ So the final build.gradle file results like:
 
 ```gradle
 buildscript {
-    dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.2.6.RELEASE")
+    repositories {
+        mavenCentral()
     }
+    dependencies {
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.3.1.RELEASE")
+    }	
+
 }
 
-apply plugin: 'spring-boot'
 apply plugin: 'java'
-apply plugin: 'maven'
-
+apply plugin: 'spring-boot'
+ 
 repositories {
     mavenCentral()
     maven {
-        url "http://193.175.132.176:8081/nexus/content/groups/public"
+            url "http://193.175.132.176:8081/nexus/content/groups/public"
     }
 }
 
 dependencies {
-    compile 'org.openbaton:vnfm-sdk-jms:0.15'
-    compile 'org.hibernate:hibernate-core:4.3.10.Final'
+    compile ("org.openbaton:vnfm-sdk-jms:0.15")
+    compile ("org.hibernate:hibernate-core:4.3.10.Final")
 }
 
-group = 'your.group'
-version = 1.0-SNAPSHOT
+group 'your.group'
+version '1.0-SNAPSHOT'
+ 
+bootRepackage {
+    mainClass = 'org.openbaton.vnfm.SimpleVNFM'
+}
 ```
 
 Once you did this, you need to trigger the gradle build process by running the following command via the command line in your project's root folder.

--- a/docs/vnfpackage.md
+++ b/docs/vnfpackage.md
@@ -337,7 +337,7 @@ Now where we onboarded the VNFPackages they are available on the NFVO and we can
 To get the ids of the newly created VNFDs you need to fetch the VNFDs by invoking the following command:
 
 ```bash
-$ curl -X "GET http://localhost:8080/api/v1/vnf-descriptors"
+$ curl -X GET "http://localhost:8080/api/v1/vnf-descriptors"
 ```
 
 This request will return a list of already existing VNFDs.


### PR DESCRIPTION
OS: Ubuntu 14.04 64b
Trying to build a sample VNFM
Following the doc I got the following error:

openbaton@openbaton-VBox01:~/develop/openbaton/nr/simple-vnfm$ gradle wrapper --gradle-version 2.4

FAILURE: Build failed with an exception.
- What went wrong:
  Could not resolve all dependencies for configuration ':classpath'.
  > Could not find org.springframework.boot:spring-boot-gradle-plugin:1.2.6.RELEASE.
  Required by:
      :simple-vnfm:unspecified

Looking at the spring-boot documentation it seems that the minimum required gradle version is 1.12:
http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-system-requirements
Ubuntu 14.04 gradle default version is (apt-get) is 1.4
Updated doc accordingly

spring-boot documentation also suggest maven 3.2
Shall we add this dependency as well to the doc?
